### PR TITLE
Not merge all scripts

### DIFF
--- a/src/ScriptCs.ComponentModel.Composition.Test/ScriptCsCatalogFacts.cs
+++ b/src/ScriptCs.ComponentModel.Composition.Test/ScriptCsCatalogFacts.cs
@@ -1,4 +1,4 @@
-﻿using Moq;
+using Moq;
 using ScriptCs.Contracts;
 using Should;
 using System;
@@ -59,6 +59,25 @@ namespace ScriptCs.ComponentModel.Composition.Test
                 var scriptName2 = @"c:\workingdirectory\DoubleScript.csx";
                 var scriptCsCatalog = new ScriptCsCatalog(new[] { scriptName, scriptName2 },
                     GetOptions(fileSystem: GetMockFileSystem(new[] { scriptName, scriptName2 }, new[] { Scripts.SimpleScript, Scripts.DoubleScript }).Object));
+
+                // act
+                var mefHost = GetComposedMefHost(scriptCsCatalog);
+
+                // assert
+                mefHost.Plugins.ShouldNotBeNull();
+                mefHost.Plugins.Count.ShouldEqual(2);
+                mefHost.Plugins[0].DoSomething().ShouldEqual("Simple");
+                mefHost.Plugins[1].DoSomething().ShouldEqual("Double");
+            }
+
+            [Fact]
+            public void ShouldWorkWithMultipleScriptsNotMerged()
+            {
+                // arrange
+                var scriptName = @"c:\workingdirectory\SimpleScript.csx";
+                var scriptName2 = @"c:\workingdirectory\DoubleScript.csx";
+                var scriptCsCatalog = new ScriptCsCatalog(new[] { scriptName, scriptName2 },
+                    GetOptions(fileSystem: GetMockFileSystem(new[] { scriptName, scriptName2 }, new[] { Scripts.SimpleScript, Scripts.DoubleScript }).Object, keepScriptsSeparated: true));
 
                 // act
                 var mefHost = GetComposedMefHost(scriptCsCatalog);
@@ -732,13 +751,14 @@ namespace ScriptCs.ComponentModel.Composition.Test
             return mefHost;
         }
 
-        private static ScriptCsCatalogOptions GetOptions(string[] scriptArgs = null, Type[] references = null, IFileSystem fileSystem = null)
+        private static ScriptCsCatalogOptions GetOptions(string[] scriptArgs = null, Type[] references = null, IFileSystem fileSystem = null, bool keepScriptsSeparated = false)
         {
             return new ScriptCsCatalogOptions
             {
                 FileSystem = fileSystem,
                 References = references,
-                ScriptArgs = scriptArgs
+                ScriptArgs = scriptArgs,
+                KeepScriptsSeparated = keepScriptsSeparated
             };
         }
 

--- a/src/ScriptCs.ComponentModel.Composition.Test/ScriptCsCatalogOptionsFacts.cs
+++ b/src/ScriptCs.ComponentModel.Composition.Test/ScriptCsCatalogOptionsFacts.cs
@@ -57,6 +57,7 @@ namespace ScriptCs.ComponentModel.Composition.Test
                 var options = new ScriptCsCatalogOptions { ScriptArgs = null };
 
                 // act
+
                 var result = options.OverridesNullByDefault();
 
                 // assert
@@ -118,6 +119,20 @@ namespace ScriptCs.ComponentModel.Composition.Test
                 // assert
                 result.FileSystem.ShouldNotBeNull();
                 result.FileSystem.ShouldEqual(fileSystemMock);
+            }
+            
+            
+            [Fact]
+            public void ShouldNotOverridesValuedKeepScriptsSeparated()
+            {
+                // arrange
+                var options = new ScriptCsCatalogOptions { KeepScriptsSeparated = true };
+
+                // act
+                var result = options.OverridesNullByDefault();
+
+                // assert
+                result.KeepScriptsSeparated.ShouldEqual(true);
             }
         }
     }

--- a/src/ScriptCs.ComponentModel.Composition/ScriptCsCatalogOptions.cs
+++ b/src/ScriptCs.ComponentModel.Composition/ScriptCsCatalogOptions.cs
@@ -40,7 +40,8 @@ namespace ScriptCs.ComponentModel.Composition
                 References = References,
                 ScriptArgs = ScriptArgs ?? new string[0],
                 FileSystem = FileSystem ?? new FileSystem(),
-                Modules = Modules ?? new string[0]
+                Modules = Modules ?? new string[0],
+                KeepScriptsSeparated = KeepScriptsSeparated
             };
         }
     }

--- a/src/ScriptCs.ComponentModel.Composition/ScriptCsCatalogOptions.cs
+++ b/src/ScriptCs.ComponentModel.Composition/ScriptCsCatalogOptions.cs
@@ -28,6 +28,11 @@ namespace ScriptCs.ComponentModel.Composition
         /// </summary>
         public string[] Modules { get; set; }
 
+        /// <summary>
+        /// Prevents the scripts from beeing merged.
+        /// </summary>
+        public bool KeepScriptsSeparated { get; set; }
+
         internal ScriptCsCatalogOptions OverridesNullByDefault()
         {
             return new ScriptCsCatalogOptions


### PR DESCRIPTION
Fix #10.
ExecuteScript called for every csx file to support using alias directives.
Now no script merging is performed anymore.